### PR TITLE
fix issue when unsetting parser

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -279,7 +279,7 @@ class Config implements ConfigInterface
     public function unregisterParser(string $parser) : bool
     {
         if (($key = \array_search($parser, $this->registeredParsers, true)) !== false) {
-            \unset($this->registeredParsers[$key]);
+            unset($this->registeredParsers[$key]);
             $this->updateFiletypeList();
             return true;
         }


### PR DESCRIPTION
do not use global namespace prefix for unset